### PR TITLE
Use type for array payload

### DIFF
--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -20,7 +20,7 @@ export interface UserOptions {
 export interface TrackPageViewParams {
   documentTitle?: string
   href?: string | Location
-  customDimensions?: boolean | []
+  customDimensions?: boolean | CustomDimension[]
 }
 
 export interface TrackParams extends TrackPageViewParams {


### PR DESCRIPTION
The ts compiler complains about an untyped empty array being required here. This will enable type checking for the custom dimensions.