### PR TITLE
Check if window exists to avoid breaking SSR

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,7 +1,9 @@
 import MatomoTracker from './MatomoTracker'
 import * as types from './types'
 
-window.MatomoTracker = MatomoTracker
+if (typeof window !== 'undefined') {
+  window.MatomoTracker = MatomoTracker
+}
 
 export default MatomoTracker
 


### PR DESCRIPTION
Just checks whether `window` exists before trying to add `MatomoTracker` to it. This avoids crashing apps that have server-side rendering when running on Node.