### PR TITLE
Feature request: Do not depend on client code providing trailing slash

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -39,7 +39,7 @@ Before you're able to use this Matomo Tracker you need to initialize Matomo with
 
 ```js
 const MatomoInstance = new window.MatomoTracker({
-  urlBase: 'https://LINK.TO.DOMAIN/',
+  urlBase: 'https://LINK.TO.DOMAIN',
   siteId: 3, // optional, default value: `1`
   trackerUrl: 'https://LINK.TO.DOMAIN/tracking.php', // optional, default value: `${urlBase}matomo.php`
   srcUrl: 'https://LINK.TO.DOMAIN/tracking.js', // optional, default value: `${urlBase}matomo.js`

--- a/packages/js/example/index.html
+++ b/packages/js/example/index.html
@@ -30,7 +30,7 @@
     <script src="../bundle.min.js"></script>
     <script>
       const MatomoInstance = new window.MatomoTracker.default({
-        urlBase: 'https://analytics.data.amsterdam.nl/',
+        urlBase: 'https://analytics.data.amsterdam.nl',
         siteId: 3,
       })
 

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -21,6 +21,10 @@ class MatomoTracker {
 
   // Initializes the Matomo Tracker
   static initialize({ urlBase, siteId, trackerUrl, srcUrl }: UserOptions) {
+    if (urlBase[urlBase.length - 1] !== '/') {
+      urlBase = urlBase + '/'
+    }
+
     window._paq = window._paq || []
 
     if (window._paq.length === 0) {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,7 +14,7 @@ Before you're able to use this Matomo Tracker you need to create a Matomo instan
 import { MatomoProvider, createInstance } from '@datapunt/matomo-tracker-react'
 
 const instance = createInstance({
-  urlBase: "https://LINK.TO.DOMAIN/",
+  urlBase: "https://LINK.TO.DOMAIN",
   siteId: 3, // optional, default value: `1`
   trackerUrl: "https://LINK.TO.DOMAIN/tracking.php", // optional, default value: `${urlBase}matomo.php`
   srcUrl: "https://LINK.TO.DOMAIN/tracking.js" // optional, default value: `${urlBase}matomo.js`

--- a/packages/react/src/useMatomo.test.tsx
+++ b/packages/react/src/useMatomo.test.tsx
@@ -38,7 +38,7 @@ describe('useMatomo', () => {
     }))
 
     const instance = createInstance({
-      urlBase: 'https://LINK.TO.DOMAIN/',
+      urlBase: 'https://LINK.TO.DOMAIN',
       siteId: 3, // optional, default value: `1`
     })
 


### PR DESCRIPTION
Just a little ergonomic feature request here.

I have noticed that the lib assumes that the client code always provides a trailing slash for the `urlBase` parameter. This pull request makes it so that, even if a parameter in the form `https://myinstance.matomo.cloud` is provided, everything keeps working.

**Questions:**

Did I introduce the change where you folks expected it to be introduced?

What should I do about packages/js/bundle.min.js? It seems to be a build result and I kept it out of the PR commit to keep review easier. But I can include it once we reach an approved status for all the source file changes. Just let me know what you prefer.