### PR TITLE
Fix main build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "lerna exec --scope @datapunt/matomo-tracker-js -- yarn build && tsc -b --clean && tsc -b packages/**/tsconfig.json && tsc -b packages/**/tsconfig.es.json",
+    "build": "lerna exec --scope @datapunt/matomo-tracker-js -- yarn build && tsc -b --clean && tsc -b packages/js/tsconfig.json && tsc -b packages/js/tsconfig.es.json",
     "clean:generated": "find ./packages -name \"*.d.ts\" -type f -delete && find ./packages -name \"*.tsbuildinfo\" -type f -delete",
     "start": "yarn build -w",
     "start:example:js": "yarn build && npx http-server ./packages/js -o /example",


### PR DESCRIPTION
The `build` script is broken:

```
yarn run build
...
error TS5083: Cannot read file 'XXX/matomo-tracker/packages/**/tsconfig.json'.


Found 1 error.

error Command failed with exit code 1.
```

Seems that the tsc file must be a specific file, not a glob

By the way:
When it's not possible to run `build`, it's not possible to run `test` and it's not possible to push commits as the `pre-push` hook depends on it