### PR TITLE
Fix prettier path on Windows

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+es/
 lib/
 *.d.ts
 node_modules/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:example:js": "yarn build && npx http-server ./packages/js -o /example",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "jest",
-    "prettier": "prettier --write './packages/**/**/*.{ts,tsx}'",
+    "prettier": "prettier --write ./packages/**/**/*.{ts,tsx}",
     "prepublishOnly": "yarn build",
     "postinstall": "lerna link"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:example:js": "yarn build && npx http-server ./packages/js -o /example",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "jest",
-    "prettier": "prettier --write ./packages/**/src/*.{ts,tsx}",
+    "prettier": "prettier --write ./packages/**/**/*.{ts,tsx}",
     "prepublishOnly": "yarn build",
     "postinstall": "lerna link"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:example:js": "yarn build && npx http-server ./packages/js -o /example",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "jest",
-    "prettier": "prettier --write ./packages/**/**/*.{ts,tsx}",
+    "prettier": "prettier --write ./packages/**/src/*.{ts,tsx}",
     "prepublishOnly": "yarn build",
     "postinstall": "lerna link"
   },


### PR DESCRIPTION
The `prettier` script is broken on Windows:

```
yarn run prettier
...
[error] No files matching the pattern were found: "'./packages/**/**/*.{ts,tsx}'".
error Command failed with exit code 2.
```

Paths in package.json should not use single quote, but an escaped double quote (as in the [`clean:generated`](https://github.com/Amsterdam/matomo-tracker/blob/v0.1.5/package.json#L5) script) or no quote (as in other scripts).