### PR TITLE
Fix instantiation instructions for matomo-tracker-js

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -63,7 +63,7 @@ After initialization you can use the Matomo Tracker to track events and page vie
 ```js
 import MatomoTracker from '@datapunt/matomo-tracker-js'
 
-const MatomoInstance = new MatomoTracker({
+const MatomoInstance = new window.MatomoTracker({
   /* setup */
 })
 
@@ -88,7 +88,7 @@ By default the Matomo Tracker will send the window's document title and location
 ```js
 import MatomoTracker from '@datapunt/matomo-tracker-js'
 
-const MatomoInstance = new MatomoTracker({
+const MatomoInstance = new window.MatomoTracker({
   /* setup */
 })
 
@@ -129,7 +129,7 @@ Next to the tracking of events, this project also supports tracking site searche
 ```js
 import MatomoTracker from '@datapunt/matomo-tracker-js'
 
-const MatomoInstance = new MatomoTracker({
+const MatomoInstance = new window.MatomoTracker({
   /* setup */
 })
 


### PR DESCRIPTION
See #186 

Readme states that MatomoTracker instance may be initialized like so

```js
import MatomoTracker from '@datapunt/matomo-tracker-js'
const MatomoInstance = new window.MatomoTracker({})
```

and later uses syntax without window:

```js
import MatomoTracker from '@datapunt/matomo-tracker-js'
const MatomoInstance = new MatomoTracker({})
```

however latter doesn't work