### PR TITLE
[DI-1167] Call trackLink function with instance context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+# UNRELEASED
+
+- Fixed: External links not being tracked
+
 ## [0.3.0]
 
 - Changed: methods returned from `useMatomo` are now memoized so they can be tracked as dependencies (for example in `useEffect`)

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -3,29 +3,23 @@ import { MatomoInstance } from '../types'
 
 const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
   const handleOutboundClick = (event: MouseEvent) => {
-    if (!event.target) {
-      return
-    }
-
     const { target } = event
-    const { nodeName } = target as HTMLElement
 
-    if (nodeName !== 'A') {
+    if (!(target instanceof HTMLAnchorElement)) {
       return
     }
 
-    const { href } = target as HTMLAnchorElement // We know from the nodeName that the element is an anchor
+    const { href } = target
 
     // Check if the click target differs from the current hostname, meaning it's external
     if (
       // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-      !href?.match(
+      !href.match(
         new RegExp(
           `^(http://www.|https://www.|http://|https://)+(${window.location.hostname})`,
         ),
       )
     ) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
       matomoInstance.trackLink({ href })
     }
   }

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { MatomoInstance } from '../types'
 
-const useOutboundClickListener = ({ trackLink }: MatomoInstance): void => {
+const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
   const handleOutboundClick = (event: MouseEvent) => {
     if (!event.target) {
       return
@@ -10,7 +10,7 @@ const useOutboundClickListener = ({ trackLink }: MatomoInstance): void => {
     const { target } = event
     const { nodeName } = target as HTMLElement
 
-    if (nodeName === 'A' && trackLink) {
+    if (nodeName === 'A' && matomoInstance.trackLink) {
       const { href } = target as HTMLAnchorElement // We know from the nodeName that the element is an anchor
       // Check if the click target differs from the current hostname, meaning it's external
       if (
@@ -22,13 +22,13 @@ const useOutboundClickListener = ({ trackLink }: MatomoInstance): void => {
           ),
         )
       ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        trackLink({ href })
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        matomoInstance.trackLink.call(matomoInstance, { href })
       }
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.document.addEventListener('click', handleOutboundClick)
 
     return () =>

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -10,21 +10,23 @@ const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
     const { target } = event
     const { nodeName } = target as HTMLElement
 
-    if (nodeName === 'A' && matomoInstance.trackLink) {
-      const { href } = target as HTMLAnchorElement // We know from the nodeName that the element is an anchor
-      // Check if the click target differs from the current hostname, meaning it's external
-      if (
-        href &&
-        // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-        !href.match(
-          new RegExp(
-            `^(http://www.|https://www.|http://|https://)+(${window.location.hostname})`,
-          ),
-        )
-      ) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-        matomoInstance.trackLink.call(matomoInstance, { href })
-      }
+    if (nodeName !== 'A') {
+      return
+    }
+
+    const { href } = target as HTMLAnchorElement // We know from the nodeName that the element is an anchor
+
+    // Check if the click target differs from the current hostname, meaning it's external
+    if (
+      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+      !href?.match(
+        new RegExp(
+          `^(http://www.|https://www.|http://|https://)+(${window.location.hostname})`,
+        ),
+      )
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+      matomoInstance.trackLink({ href })
     }
   }
 


### PR DESCRIPTION
This PR fixes the "TypeError: Cannot read property 'pushInstruction' of undefined" error that was thrown whenever an outbound link was clicked. The `trackLink` function didn't have any context and would thus throw that error.