### PR TITLE
The outbound click listener does not work with a tags with complex DOM children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [Unreleased]
+
+- Added: Support outbound links on `<a>` child elements.
+
 ## [0.4.0]
 
 - Added: Support React v17

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -3,7 +3,18 @@ import { MatomoInstance } from '../types'
 
 const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
   const handleOutboundClick = (event: MouseEvent) => {
-    const { target } = event
+    // The target is not guaranteed to be a link, it could be a child element.
+    // Look up the element's parent until the anchor element is found.
+    const findLinkElement = (el) => {
+      if (el instanceof HTMLAnchorElement && el.href) {
+        return el
+      } else if (el && el.parentElement) {
+        return findLinkElement(el.parentElement)
+      }
+      return null
+    }
+
+    const target = findLinkElement(event.target)
 
     if (!(target instanceof HTMLAnchorElement)) {
       return

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -8,7 +8,8 @@ const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
     const findLinkElement = (el: EventTarget | null): HTMLElement | null => {
       if (el instanceof HTMLAnchorElement && el.href) {
         return el
-      } else if (el instanceof HTMLElement && el.parentElement) {
+      } 
+      if (el instanceof HTMLElement && el.parentElement) {
         return findLinkElement(el.parentElement)
       }
       return null

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -8,7 +8,7 @@ const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
     const findLinkElement = (el: EventTarget | null): HTMLElement | null => {
       if (el instanceof HTMLAnchorElement && el.href) {
         return el
-      } 
+      }
       if (el instanceof HTMLElement && el.parentElement) {
         return findLinkElement(el.parentElement)
       }

--- a/packages/react/src/utils/useOutboundClickListener.tsx
+++ b/packages/react/src/utils/useOutboundClickListener.tsx
@@ -5,10 +5,10 @@ const useOutboundClickListener = (matomoInstance: MatomoInstance): void => {
   const handleOutboundClick = (event: MouseEvent) => {
     // The target is not guaranteed to be a link, it could be a child element.
     // Look up the element's parent until the anchor element is found.
-    const findLinkElement = (el) => {
+    const findLinkElement = (el: EventTarget | null): HTMLElement | null => {
       if (el instanceof HTMLAnchorElement && el.href) {
         return el
-      } else if (el && el.parentElement) {
+      } else if (el instanceof HTMLElement && el.parentElement) {
         return findLinkElement(el.parentElement)
       }
       return null


### PR DESCRIPTION
Add support for the onclick event of AnchorElements child elements.
