### PR TITLE
Add getEcommerceItems getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [0.5.0]
+
+- Added: `getEcommerceItems` getter
+
 ## [0.4.0]
 
 - Added: Support React v17

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -29,6 +29,7 @@ const tracker = new MatomoTracker({
     seconds: 10 // optional, default value: `15
   },
   linkTracking: false, // optional, default value: true
+  alwaysUseSendBeacon: true, // optional, default value: true
   configurations: { // optional, default value: {}
     // any valid matomo configuration, all below are optional
     disableCookies: true,

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -58,8 +58,6 @@ class MatomoTracker {
       return
     }
 
-    this.asyncTrackers = window.Matomo.getAsyncTrackers()
-
     this.pushInstruction(
       'setTrackerUrl',
       trackerUrl ?? `${normalizedUrlBase}matomo.php`,
@@ -92,6 +90,9 @@ class MatomoTracker {
     scriptElement.async = true
     scriptElement.defer = true
     scriptElement.src = srcUrl || `${normalizedUrlBase}matomo.js`
+    scriptElement.onload = () => {
+      this.asyncTrackers = window.Matomo.getAsyncTrackers()
+    }
 
     if (scripts && scripts.parentNode) {
       scripts.parentNode.insertBefore(scriptElement, scripts)

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -243,7 +243,7 @@ class MatomoTracker {
   // Return all ecommerce items currently in the untracked ecommerce order.
   // https://matomo.org/docs/ecommerce-analytics
   getEcommerceItems(): EcommerceItems {
-    return this.callMethod('getEcommerceItems') as EcommerceItems
+    return (this.callMethod('getEcommerceItems') || {}) as EcommerceItems
   }
 
   // Tracks an Ecommerce order containing items added via addEcommerceItem.

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -83,12 +83,6 @@ class MatomoTracker {
     // // might not work accurately on SPAs because new links (dom elements) are created dynamically without a server-side page reload.
     this.enableLinkTracking(linkTracking)
 
-    // If enabled (default), always use sendBeacon if the browser supports it
-    // Disabling this makes sense when you're waiting for a tracking operation to be done and immediately do a page redirect afterwards.
-    if (alwaysUseSendBeacon === false) {
-      this.callMethod('disableAlwaysUseSendBeacon')
-    }
-
     const doc = document
     const scriptElement = doc.createElement('script')
     const scripts = doc.getElementsByTagName('script')[0]
@@ -99,6 +93,12 @@ class MatomoTracker {
     scriptElement.src = srcUrl || `${normalizedUrlBase}matomo.js`
     scriptElement.onload = () => {
       this.asyncTrackers = window.Matomo.getAsyncTrackers()
+
+      // If enabled (default), always use sendBeacon if the browser supports it
+      // Disabling this makes sense when you're waiting for a tracking operation to be done and immediately do a page redirect afterwards.
+      if (alwaysUseSendBeacon === false) {
+        this.callMethod('disableAlwaysUseSendBeacon')
+      }
     }
 
     if (scripts && scripts.parentNode) {

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -39,6 +39,7 @@ class MatomoTracker {
     disabled,
     heartBeat,
     linkTracking = true,
+    alwaysUseSendBeacon = true,
     configurations = {},
   }: UserOptions) {
     const normalizedUrlBase =
@@ -81,6 +82,12 @@ class MatomoTracker {
     // // measure outbound links and downloads
     // // might not work accurately on SPAs because new links (dom elements) are created dynamically without a server-side page reload.
     this.enableLinkTracking(linkTracking)
+
+    // If enabled (default), always use sendBeacon if the browser supports it
+    // Disabling this makes sense when you're waiting for a tracking operation to be done and immediately do a page redirect afterwards.
+    if (alwaysUseSendBeacon === false) {
+      this.callMethod('disableAlwaysUseSendBeacon')
+    }
 
     const doc = document
     const scriptElement = doc.createElement('script')

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -4,6 +4,9 @@ import * as types from './types'
 declare global {
   interface Window {
     _paq: [string, ...any[]][]
+    Matomo: {
+      getAsyncTrackers: () => types.AsyncTracker[]
+    }
   }
 }
 

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -17,6 +17,7 @@ export interface UserOptions {
     seconds?: number
   }
   linkTracking?: boolean
+  alwaysUseSendBeacon?: boolean
   configurations?: {
     [key: string]: any
   }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -1,3 +1,5 @@
+export type AsyncTracker = any
+
 export interface CustomDimension {
   id: number
   value: string
@@ -71,3 +73,8 @@ export interface SetEcommerceViewParams {
   productCategory?: string
   productPrice?: number
 }
+
+export type EcommerceItems = Record<
+  number,
+  [string, string, string, number, number]
+>


### PR DESCRIPTION
This PR adds the missing getter.

Since the whole architecture is designed for pushing to matomo (pushInstruction) and not pulling, I've tried to find a way to access all those methods, mentioned in the matomo docs.

My solution is using `window.Matomo.getAsyncTrackers()` because an asyncTracker seems to provide all those methods. Not sure if that's the intended/best usage, but it's at least working.
I've added a private method `callMethod` so it can be reused for other missing getters if someone needs it.

Closes #566 