### PR TITLE
Support all the data which matomo supports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Prefix the change with one of these keywords:
 - _Fixed_: for any bug fixes.
 - _Security_: in case of vulnerabilities.
 
+## [0.5.0]
+
+- Added: Support callback and other possible data
+
 ## [0.4.0]
 
 - Added: Support React v17

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -29,7 +29,6 @@ const tracker = new MatomoTracker({
     seconds: 10 // optional, default value: `15
   },
   linkTracking: false, // optional, default value: true
-  alwaysUseSendBeacon: true, // optional, default value: true
   configurations: { // optional, default value: {}
     // any valid matomo configuration, all below are optional
     disableCookies: true,
@@ -158,20 +157,6 @@ tracker.trackEvents()
 // Track page views
 tracker.trackPageView()
 ```
-
-## Asynchronous Tracking
-
-Matomo is working asynchronously by concept. If you need to wait until a tracking operation is done, you can pass an callback to `trackPageView` or `trackEvent`
-
-```typescript
-trackPageView({
-  callback: () => {
-    console.log('done')
-  },
-})
-```
-
-If you're making a page redirect immediately after the tracking operation is done, you should consider to set `alwaysUseSendBeacon` to `false`.
 
 ## References
 

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -29,6 +29,7 @@ const tracker = new MatomoTracker({
     seconds: 10 // optional, default value: `15
   },
   linkTracking: false, // optional, default value: true
+  alwaysUseSendBeacon: true, // optional, default value: true
   configurations: { // optional, default value: {}
     // any valid matomo configuration, all below are optional
     disableCookies: true,
@@ -157,6 +158,20 @@ tracker.trackEvents()
 // Track page views
 tracker.trackPageView()
 ```
+
+## Asynchronous Tracking
+
+Matomo is working asynchronously by concept. If you need to wait until a tracking operation is done, you can pass an callback to `trackPageView` or `trackEvent`
+
+```typescript
+trackPageView({
+  callback: () => {
+    console.log('done')
+  },
+})
+```
+
+If you're making a page redirect immediately after the tracking operation is done, you should consider to set `alwaysUseSendBeacon` to `false`.
 
 ## References
 

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -214,8 +214,17 @@ class MatomoTracker {
 
   // Tracks outgoing links to other sites and downloads
   // https://developer.matomo.org/guides/tracking-javascript-guide#enabling-download-outlink-tracking
-  trackLink({ href, linkType = 'link' }: TrackLinkParams): void {
-    this.pushInstruction(TRACK_TYPES.TRACK_LINK, href, linkType)
+  trackLink({
+    href,
+    linkType = 'link',
+    customData,
+    callback,
+    ...params
+  }: TrackLinkParams): void {
+    this.track({
+      data: [TRACK_TYPES.TRACK_LINK, href, linkType, customData, callback],
+      ...params,
+    })
   }
 
   // Tracks page views

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -172,11 +172,21 @@ class MatomoTracker {
     action,
     name,
     value,
+    customData,
+    callback,
     ...otherParams
-  }: TrackEventParams): void {
+  }: Omit<TrackEventParams, 'customTitle'>): void {
     if (category && action) {
       this.track({
-        data: [TRACK_TYPES.TRACK_EVENT, category, action, name, value],
+        data: [
+          TRACK_TYPES.TRACK_EVENT,
+          category,
+          action,
+          name,
+          value,
+          customData,
+          callback,
+        ],
         ...otherParams,
       })
     } else {
@@ -210,8 +220,16 @@ class MatomoTracker {
 
   // Tracks page views
   // https://developer.matomo.org/guides/spa-tracking#tracking-a-new-page-view
-  trackPageView(params?: TrackPageViewParams): void {
-    this.track({ data: [TRACK_TYPES.TRACK_VIEW], ...params })
+  trackPageView({
+    customTitle,
+    customData,
+    callback,
+    ...params
+  }: TrackPageViewParams = {}): void {
+    this.track({
+      data: [TRACK_TYPES.TRACK_VIEW, customTitle, customData, callback],
+      ...params,
+    })
   }
 
   // Adds a product to an Ecommerce order to be tracked via trackEcommerceOrder.

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -35,6 +35,7 @@ class MatomoTracker {
     disabled,
     heartBeat,
     linkTracking = true,
+    alwaysUseSendBeacon = true,
     configurations = {},
   }: UserOptions) {
     const normalizedUrlBase =
@@ -77,6 +78,9 @@ class MatomoTracker {
     // // measure outbound links and downloads
     // // might not work accurately on SPAs because new links (dom elements) are created dynamically without a server-side page reload.
     this.enableLinkTracking(linkTracking)
+
+    // If enabled, always use sendBeacon if the browser supports it
+    this.pushInstruction('alwaysUseSendBeacon', alwaysUseSendBeacon)
 
     const doc = document
     const scriptElement = doc.createElement('script')

--- a/packages/js/src/MatomoTracker.ts
+++ b/packages/js/src/MatomoTracker.ts
@@ -35,7 +35,6 @@ class MatomoTracker {
     disabled,
     heartBeat,
     linkTracking = true,
-    alwaysUseSendBeacon = true,
     configurations = {},
   }: UserOptions) {
     const normalizedUrlBase =
@@ -78,9 +77,6 @@ class MatomoTracker {
     // // measure outbound links and downloads
     // // might not work accurately on SPAs because new links (dom elements) are created dynamically without a server-side page reload.
     this.enableLinkTracking(linkTracking)
-
-    // If enabled, always use sendBeacon if the browser supports it
-    this.pushInstruction('alwaysUseSendBeacon', alwaysUseSendBeacon)
 
     const doc = document
     const scriptElement = doc.createElement('script')

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -46,7 +46,7 @@ export interface TrackEventParams extends TrackPageViewParams {
   value?: number
 }
 
-export interface TrackLinkParams {
+export interface TrackLinkParams extends TrackPageViewParams {
   href: string
   linkType?: 'download' | 'link'
 }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -21,7 +21,6 @@ export interface UserOptions {
     seconds?: number
   }
   linkTracking?: boolean
-  alwaysUseSendBeacon?: boolean
   configurations?: {
     [key: string]: any
   }

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -1,3 +1,9 @@
+// `customData` is afaik meant to be used for custom dimensions.
+// Matomo looks for keys which start which match the pattern /^dimension\d+$/
+// and extracts the dimension ID from it.
+// Example: { dimension1: 'some value' }
+export type CustomData = Record<string, unknown>
+
 export interface CustomDimension {
   id: number
   value: string
@@ -24,6 +30,9 @@ export interface TrackPageViewParams {
   documentTitle?: string
   href?: string | Location
   customDimensions?: boolean | CustomDimension[]
+  customTitle?: string
+  customData?: CustomData
+  callback?: () => void
 }
 
 export interface TrackParams extends TrackPageViewParams {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -21,6 +21,7 @@ export interface UserOptions {
     seconds?: number
   }
   linkTracking?: boolean
+  alwaysUseSendBeacon?: boolean
   configurations?: {
     [key: string]: any
   }


### PR DESCRIPTION
This PR makes it possible to pass all data that matomo already supports.
In particular the callback is super important if you need to wait for matomo.

Closes #568