### PR TITLE
Fix: add children prop type to matomo provider

### DIFF
--- a/packages/react/src/MatomoProvider.tsx
+++ b/packages/react/src/MatomoProvider.tsx
@@ -3,6 +3,7 @@ import MatomoContext from './MatomoContext'
 import { MatomoInstance } from './types'
 
 export interface MatomoProviderProps {
+  children?: React.ReactNode
   value: MatomoInstance
 }
 


### PR DESCRIPTION
[It looks like the children attribute on the typescript typings were removed](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/55dc209ceb6dbcd59c4c68cc8dfb77faadd9de12#diff-32cfd8cb197872bcba371f5018185d2e75fa540b52cda2dd7d8ac12dcc021299L500).

So we have to declare it explicitely.

