### PR TITLE
Explicit children prop in MatomoProviderProps to support React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Prefix the change with one of these keywords:
 ## [Unreleased]
 
 - Fixed: Made `trackPageView` `params` argument optional
+- Fixed: Added support for React 18 types with explicit `children` prop in `MatomoProviderProps`
 
 ## [0.5.1]
 

--- a/packages/react/src/MatomoProvider.tsx
+++ b/packages/react/src/MatomoProvider.tsx
@@ -4,6 +4,7 @@ import { MatomoInstance } from './types'
 
 export interface MatomoProviderProps {
   value: MatomoInstance
+  children?: React.ReactNode;
 }
 
 const MatomoProvider: React.FC<MatomoProviderProps> = function ({


### PR DESCRIPTION
Allows this package to be used in React 18 TS codebases as per this update: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions